### PR TITLE
Update project_rendering to remove deprecated image-type field

### DIFF
--- a/src/project_rendering/templates/product.yaml.jinja
+++ b/src/project_rendering/templates/product.yaml.jinja
@@ -54,7 +54,6 @@ product:
       - {{ advisory }}
       {%- endfor %}
       {%- endif %}
-      image-type: layered
       host-level-access: unprivileged
       {%- if build['owners'] is defined %}
       owners:

--- a/src/scripts/render_project.py
+++ b/src/scripts/render_project.py
@@ -1,3 +1,5 @@
+#!/bin/python3
+
 import project_rendering
 
 if __name__ == '__main__':

--- a/src/scripts/render_project.py
+++ b/src/scripts/render_project.py
@@ -1,5 +1,3 @@
-#!/bin/python3
-
 import project_rendering
 
 if __name__ == '__main__':

--- a/tests/case_1/output.yml
+++ b/tests/case_1/output.yml
@@ -20,7 +20,6 @@ product:
       name: component-1
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       owners:
       - wolf@brick.house
@@ -40,7 +39,6 @@ product:
       name: component-2
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       owners:
       - wolf@brick.house
@@ -60,7 +58,6 @@ product:
       name: components-bundle
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       owners:
       - foo@baz.io

--- a/tests/case_2/output.yml
+++ b/tests/case_2/output.yml
@@ -19,7 +19,6 @@ product:
       name: component-1
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       display-name: component-1
       description: "component-1 component for baz product"
@@ -36,7 +35,6 @@ product:
       name: component-2
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       display-name: component-2
       description: "component-2 component for baz product"
@@ -53,7 +51,6 @@ product:
       name: components-bundle
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       owners:
       - foo@baz.io

--- a/tests/case_2/product.yaml.jinja
+++ b/tests/case_2/product.yaml.jinja
@@ -46,7 +46,6 @@ product:
       - {{ advisory }}
       {%- endfor %}
       {%- endif %}
-      image-type: layered
       host-level-access: unprivileged
       {%- if build['owners'] is defined %}
       owners:

--- a/tests/case_3/output.yml
+++ b/tests/case_3/output.yml
@@ -17,7 +17,6 @@ product:
       name: component-1
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       display-name: component-1
       description: "component-1 component for case product"
@@ -42,7 +41,6 @@ product:
       name: component-2
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       display-name: component-2
       description: "component-2 component for case product"
@@ -67,7 +65,6 @@ product:
       name: component-3
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       owners:
       - foo@baz.trip
@@ -92,7 +89,6 @@ product:
       name: build1
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       owners:
       - wolf@brick.house
@@ -117,7 +113,6 @@ product:
       name: component-5
       advisories:
       - advisory
-      image-type: layered
       host-level-access: unprivileged
       display-name: component-5
       description: "component-5 component for case product"


### PR DESCRIPTION
## Summary of Changes

This PR removes the, [now-deprecated](https://cpaas.pages.redhat.com/documentation/users/cpaas_version_updates/migration.html#_schema_changes_2), `image-type` field from generated content.  